### PR TITLE
Setup to run npm install and compile before running extension dev window

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/vscode-heimdall"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/vscode-heimdall/dist/**/*.js"
+            ],
+            "preLaunchTask": "extension-setup"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "extension-setup",
+            "dependsOrder": "sequence",
+            "dependsOn": ["install", "compile"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "install",
+            "type": "npm",
+            "script": "install",
+            "path": "vscode-heimdall",
+            "problemMatcher": []
+        },
+        {
+            "label": "compile",
+            "type": "npm",
+            "script": "compile",
+            "path": "vscode-heimdall",
+            "problemMatcher": ["$tsc"]
+        }
+    ]
+}


### PR DESCRIPTION
Previously, clicking `F5` would not directly run the extension with the latest changes. With this change, we expect that clicking `F5` would run the entire build process.